### PR TITLE
Use setTiles to update raster sources instead of private methods

### DIFF
--- a/src/DynamicMapService.js
+++ b/src/DynamicMapService.js
@@ -94,8 +94,11 @@ export class DynamicMapService {
         src.tiles[0] = this._source.tiles[0]
         src._options = this._source
 
-        // Old MapboxGL and MaplibreGL
-        if (this._map.style.sourceCaches) {
+        if (src.setTiles) {
+            // New MapboxGL >= 2.13.0
+            src.setTiles(this._source.tiles);
+        } else if (this._map.style.sourceCaches) {
+            // Old MapboxGL and MaplibreGL
             this._map.style.sourceCaches[this._sourceId].clearTiles()
             this._map.style.sourceCaches[this._sourceId].update(this._map.transform)
         } else if (this._map.style._otherSourceCaches) {

--- a/src/ImageService.js
+++ b/src/ImageService.js
@@ -77,9 +77,11 @@ export class ImageService {
         const src = this._map.getSource(this._sourceId)
         src.tiles[0] = this._source.tiles[0]
         src._options = this._source
-
-        // Old MapboxGL and MaplibreGL
-        if (this._map.style.sourceCaches) {
+        if (src.setTiles) {
+            // New MapboxGL >= 2.13.0
+            src.setTiles(this._source.tiles);
+        } else if (this._map.style.sourceCaches) {
+            // Old MapboxGL and MaplibreGL
             this._map.style.sourceCaches[this._sourceId].clearTiles()
             this._map.style.sourceCaches[this._sourceId].update(this._map.transform)
         } else if (this._map.style._otherSourceCaches) {


### PR DESCRIPTION
Currently this library uses private methods to update raster sources. Mapbox introduced a [setTiles method](https://docs.mapbox.com/mapbox-gl-js/api/sources/#rastertilesource#settiles) which can do the same without using private function calls.

I had trouble using mapbox-gl-js v2.9 and v2.15 related to these private method calls. `sourceCaches` was available on the internal map style object but `this._sourceId` was incorrect. Somehow the correct id looked like `other:${mySourceId}` but DynamicMapService expected simply `mySourceId`, so I was getting a lot of errors about calling clearTiles on undefined. This clears up the error for me.